### PR TITLE
Fix test_package

### DIFF
--- a/recipes/gtk-doc-stub/all/test_package/conanfile.py
+++ b/recipes/gtk-doc-stub/all/test_package/conanfile.py
@@ -42,4 +42,4 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            self.run(f"gtkdocize --copy", env="conanrun")
+            self.run(f"gtkdocize --version", env="conanbuild")


### PR DESCRIPTION
As far as I understand, it lives in the build context, then text should run it from that env.

let me know if I'm wrong and we can find the proper solution :)

Also changed the flag to `--version` to have somethig to see in the output :)

Tested locally in macos, linux and windows