### PR TITLE
[mesa] Install python mesa on-the-fly

### DIFF
--- a/recipes/mesa/all/conanfile.py
+++ b/recipes/mesa/all/conanfile.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import re
+from io import StringIO
 
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
@@ -913,9 +914,11 @@ class MesaConan(ConanFile):
             self.requires("moltenvk/1.2.2")
 
     def validate(self):
-        python_version = self.run("python3 --version").strip().replace("Python ", "")
+        stdout = StringIO()
+        self.run("python3 --version", quiet=True, stdout=stdout)
+        python_version = stdout.getvalue().strip().replace("Python ", "")
         if Version(python_version) < "3.9":
-            self.output.error(f"{self.ref} internal scripts require Python 3.9 or later")
+            self.output.error(f"{self.ref} internal scripts require Python 3.9 or later. Please update your Python installation.")
 
         if self.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, self._min_cppstd)

--- a/recipes/mesa/all/conanfile.py
+++ b/recipes/mesa/all/conanfile.py
@@ -1364,10 +1364,6 @@ class MesaConan(ConanFile):
         pythonpath = glob.glob(os.path.join(self.build_folder, "venv", "lib", "python*", "site-packages"))
         self._env_pythonpath.append_path("PYTHONPATH", pythonpath)
 
-    def _get_python_path(self):
-        pythonpath = glob.glob(os.path.join(self.build_folder, "venv", "lib", "python*", "site-packages"))
-        return pythonpath[0] if pythonpath else ""
-
     def build(self):
         self._install_python_mako()
         with self._env_pythonpath.vars(self).apply():

--- a/recipes/mesa/all/conanfile.py
+++ b/recipes/mesa/all/conanfile.py
@@ -121,6 +121,7 @@ class MesaConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     short_paths = True
     # Reduce the cost of copying a lot of source code.
+    no_copy_source = True
     options = {
         "android_stub": [True, False],
         "android_libbacktrace": [True, False],
@@ -1191,15 +1192,10 @@ class MesaConan(ConanFile):
             "dep_wl_protocols = dependency('wayland-protocols', version : '>= 1.30')",
             "dep_wl_protocols = dependency('wayland-protocols_BUILD', native: true, version : '>= 1.30')",
         )
-        replace_in_file(
-            self,
-            os.path.join(self.source_folder, "meson.build"),
-            "find_installation('python3')",
-            "find_installation('python3', modules : ['mako'])",
-        )
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        self._patch_sources()
 
     def generate(self):
         def boolean(option):
@@ -1370,7 +1366,6 @@ class MesaConan(ConanFile):
         return pythonpath[0] if pythonpath else ""
 
     def build(self):
-        self._patch_sources()
         self._install_python_mako()
         with self._env_pythonpath.vars(self).apply():
             meson = Meson(self)


### PR DESCRIPTION
This PR is based on what Conan team concluded after speaking about python package as dependency.

- The recipe uses first, the system python, not Conan's python to create the virtual environment.
- Then, we use use the python from the new environment to install mako.
- The PYTHONPATH is applied on the fly, because in `generate()` we still don't know the correct path
- Mako requires python 3.8, but some internals scripts of Mesa use `remoteprefix` from Python 3.9. This will not work in CCI, we are running Python 3.7 to respect Conan 2.x minimal support (3.6)
- After having CPython ported to Conan 2.x, we could include it as tool requirement, then try to solve the Python 3.9 installation.
- I preferred not raising error related to python version, as this feature is something covered by Conan itself. So the message should work in this case.
- Tested on Linux, with Python 3.10: https://gist.github.com/uilianries/2eb6b96cdb5ac117ae3ca26968e09139

Related to https://github.com/conan-io/conan-docker-tools/pull/554

These PRs should be closed:

closes https://github.com/conan-io/conan-center-index/pull/23098
closes https://github.com/conan-io/conan-center-index/pull/23091

/cc @czoido @rubenRBS
/cc @ericLemanissier 

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
